### PR TITLE
Remove those version-specific "-isysroot" options. (for macOS)

### DIFF
--- a/hints/darwin.pl
+++ b/hints/darwin.pl
@@ -8,27 +8,14 @@ if ( $Config{myarchname} =~ /i386/ ) {
     # Match arch options with the running perl
     if ( my @archs = $Config{ccflags} =~ /-arch ([^ ]+)/g ) {
         $arch = join( '', map { "-arch $_ " } @archs );
-        
         if ( -e 'MANIFEST.SKIP' ) {
             # XXX for development, use only one arch to speed up compiles
             $arch = '-arch x86_64 ';
         }
     }
-    
-    # Read OS version
-    my $sys = `/usr/sbin/system_profiler SPSoftwareDataType`;
-    my ($osx_ver) = $sys =~ /Mac OS X.*(10\.[^ ]+)/;
-    if ( $osx_ver gt '10.5' ) {
-        # Running 10.6+, build as 10.5+
-        $arch .= "-isysroot /Developer/SDKs/MacOSX10.5.sdk -mmacosx-version-min=10.5";
-    }
-    else {
-        # 5.8.x, build for 10.3+
-        $arch .= "-isysroot /Developer/SDKs/MacOSX10.4u.sdk -mmacosx-version-min=10.3";
-    }
-    
-    print "Adding $arch\n";
-    
+
+    print "Adding $arch\n" if $arch;
+
     my $ccflags   = $Config{ccflags};
     my $ldflags   = $Config{ldflags};
     my $lddlflags = $Config{lddlflags};


### PR DESCRIPTION
Problem: `perl Makefile.PL` on macos 10.13 failed like this:

```
....
clang: warning: no such sysroot directory: '/Developer/SDKs/MacOSX10.4u.sdk' [-Wmissing-sysroot]
In file included from XS.xs:2:
/Users/gugod/perl5/perlbrew/perls/perl-5.18.2/lib/5.18.2/darwin-2level/CORE/perl.h:650:11: fatal error: 
      'sys/types.h' file not found
#       include <sys/types.h>
                ^~~~~~~~~~~~~
1 error generated.
make: *** [XS.o] Error 1
FAIL
```

Cause: The path of MacOS sdks was changed in some previous version of xcode.

Solution: remove the `-isysroot` params.

With recent versions of xcode, this seems to be handled
transparently.

Tested on a macOS 10.13.6 (High Sierra), with:

- /usr/bin/perl (5.18.2)
- /usr/local/bin/perl (homebrew, 5.30.0)
- a perl-5.18.2 installed done via perlbrew