### PR TITLE
Fix release dates in Changes file

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,7 +10,7 @@ Revision history for Perl extension Thrift::XS.
         - 1.09-TRIAL Removed the embedded (but unindexed) Thrift (Tim Legge)
         - Thrift is now a dependency
 
-1.09    2027-03-10
+1.09    2026-03-10
         - Remove the embedded (but unindexed) Thrift (Tim Legge) which
         fixes RT #173209	
         - The git repo accidentally has the unsquashed commits that
@@ -21,10 +21,10 @@ Revision history for Perl extension Thrift::XS.
             - Replace references to TTransportException with Thrift::TTransportException
             - Replace references to TType with Thrift::TType
 
-1.08    2027-02-16
+1.08    2026-02-16
         Fix smoker failures on old gcc versions (Tim Legge)
 
-1.07    2027-02-14
+1.07    2026-02-14
         Fix some smoker failures due to the endianness checks (Tim Legge)
 
 1.06    2026-01-28


### PR DESCRIPTION
This PR corrects the release dates for releases 1.07, 1.08, and 1.09. I presumed no time travel was involved.

Ping @timlegge